### PR TITLE
RISC-V: Use v2 syscalls when appropriate

### DIFF
--- a/arch/riscv32/bits/syscall.h.in
+++ b/arch/riscv32/bits/syscall.h.in
@@ -36,7 +36,6 @@
 #define __NR_unlinkat 35
 #define __NR_symlinkat 36
 #define __NR_linkat 37
-#define __NR_renameat 38
 #define __NR_umount2 39
 #define __NR_mount 40
 #define __NR_pivot_root 41

--- a/arch/riscv64/bits/syscall.h.in
+++ b/arch/riscv64/bits/syscall.h.in
@@ -36,7 +36,6 @@
 #define __NR_unlinkat 35
 #define __NR_symlinkat 36
 #define __NR_linkat 37
-#define __NR_renameat 38
 #define __NR_umount2 39
 #define __NR_mount 40
 #define __NR_pivot_root 41

--- a/src/mman/mlock.c
+++ b/src/mman/mlock.c
@@ -3,5 +3,9 @@
 
 int mlock(const void *addr, size_t len)
 {
+#ifdef SYS_mlock
 	return syscall(SYS_mlock, addr, len);
+#else
+	return syscall(SYS_mlock2, addr, len, 0);
+#endif
 }

--- a/src/stdio/rename.c
+++ b/src/stdio/rename.c
@@ -7,6 +7,10 @@ int rename(const char *old, const char *new)
 #ifdef SYS_rename
 	return syscall(SYS_rename, old, new);
 #else
+#ifdef SYS_renameat2
+	return syscall(SYS_renameat2, AT_FDCWD, old, AT_FDCWD, new, 0);
+#else
 	return syscall(SYS_renameat, AT_FDCWD, old, AT_FDCWD, new);
+#endif
 #endif
 }

--- a/src/unistd/renameat.c
+++ b/src/unistd/renameat.c
@@ -3,5 +3,9 @@
 
 int renameat(int oldfd, const char *old, int newfd, const char *new)
 {
+#ifdef SYS_renameat
 	return syscall(SYS_renameat, oldfd, old, newfd, new);
+#else
+	return syscall(SYS_renameat2, oldfd, old, newfd, new, 0);
+#endif
 }


### PR DESCRIPTION
The RISC-V port does not support any legacy syscalls.