### PR TITLE
RISC-V: Add cache flush syscall

### DIFF
--- a/arch/riscv32/bits/syscall.h.in
+++ b/arch/riscv32/bits/syscall.h.in
@@ -274,4 +274,5 @@
 #define __NR_pkey_alloc 289
 #define __NR_pkey_free 290
 #define __NR_sysriscv __NR_arch_specific_syscall
+#define __NR_riscv_flush_icache (__NR_sysriscv + 15)
 

--- a/arch/riscv64/bits/syscall.h.in
+++ b/arch/riscv64/bits/syscall.h.in
@@ -274,4 +274,5 @@
 #define __NR_pkey_alloc 289
 #define __NR_pkey_free 290
 #define __NR_sysriscv __NR_arch_specific_syscall
+#define __NR_riscv_flush_icache (__NR_sysriscv + 15)
 

--- a/arch/riscv64/syscall_arch.h
+++ b/arch/riscv64/syscall_arch.h
@@ -74,3 +74,6 @@ static inline long __syscall6(long n, long a, long b, long c, long d, long e, lo
 /* We don't have a clock_gettime function.
 #define VDSO_CGT_SYM "__vdso_clock_gettime"
 #define VDSO_CGT_VER "LINUX_2.6" */
+
+#define VDSO_FLUSH_ICACHE_SYM "__vdso_flush_icache"
+#define VDSO_FLUSH_ICACHE_VER "LINUX_4.5"

--- a/src/linux/cache.c
+++ b/src/linux/cache.c
@@ -1,4 +1,6 @@
+#include <errno.h>
 #include "syscall.h"
+#include "atomic.h"
 
 #ifdef SYS_cacheflush
 int _flush_cache(void *addr, int len, int op)
@@ -14,4 +16,39 @@ int __cachectl(void *addr, int len, int op)
 	return syscall(SYS_cachectl, addr, len, op);
 }
 weak_alias(__cachectl, cachectl);
+#endif
+
+#ifdef SYS_riscv_flush_icache
+
+#ifdef VDSO_FLUSH_ICACHE_SYM
+
+static void *volatile vdso_func;
+
+static int flush_icache_init(void *start, void *end, unsigned long int flags)
+{
+	void *p = __vdsosym(VDSO_FLUSH_ICACHE_VER, VDSO_FLUSH_ICACHE_SYM);
+	int (*f)(void *, void *, unsigned long int) =
+		(int (*)(void *, void *, unsigned long int))p;
+	a_cas_p(&vdso_func, (void *)flush_icache_init, p);
+	return f ? f(start, end, flags) : -ENOSYS;
+}
+
+static void *volatile vdso_func = (void *)flush_icache_init;
+
+#endif
+
+int __riscv_flush_icache(void *start, void *end, unsigned long int flags) 
+{
+#ifdef VDSO_FLUSH_ICACHE_SYM
+	int (*f)(void *, void *, unsigned long int) =
+		(int (*)(void *, void *, unsigned long int))vdso_func;
+	if (f) {
+		int r = f(start, end, flags);
+		if (!r) return r;
+		if (r != -ENOSYS) return __syscall_ret(r);
+	}
+#endif
+	return syscall(SYS_riscv_flush_icache, start, end, flags);
+}
+weak_alias(__riscv_flush_icache, riscv_flush_icache);
 #endif


### PR DESCRIPTION
This is necessary, for example, for libffi.